### PR TITLE
New post: If Claude Writes the Code, What Makes Me Still a Developer?

### DIFF
--- a/_research/not-the-same-job/draft.md
+++ b/_research/not-the-same-job/draft.md
@@ -1,0 +1,91 @@
+# Still a Developer (I Think)
+
+It's been three months since I last wrote a line of code.
+
+I still deliver features. I still solve problems, tackle architecture challenges, review PRs. I'm not a PM. I'm not a tech lead with a team of agents. I still consider myself a developer. But I am not doing the same job I was doing a year ago.
+
+## The gradient, not the cliff
+
+There was no single moment where I thought "this isn't the same job anymore." It was a progressive process. First Cursor, mostly the Tab autocomplete — and even that [changed my mind about AI coding](/two-hours). Then agent mode — Codex, Claude Code, Cursor again. I've [written before](/three-act-play) about these different approaches. Now I work exclusively with Claude Code, with custom skills my team and I built for planning, shaping, building, and compounding.
+
+The shift was gradual enough that I only felt the full weight of it in retrospect. If you're somewhere on that spectrum — using Copilot for autocomplete, or you've tried agent mode once or twice — you're on the same gradient. You just haven't looked back yet.
+
+## What I actually do all day
+
+So if I don't write code, what do I do?
+
+With my team, we built a set of Claude Code skills we call the Conductor. It grew out of [my early experiments with plan-driven development](/design-partner), and it covers our entire workflow in five phases:
+
+- **Research.** I ask Claude to research the feature I need to build. It pulls from the existing codebase, our Notion pages, Slack conversations, the web — whatever's relevant. The output is a Markdown document with all the research content, and more importantly, a list of open questions.
+- **Shaping.** We shape the feature to make sure the problem and the chosen solution are clear. At the end of the shaping, there should ideally be no more unknowns — the document should be understandable by any non-technical person.
+- **Planning.** From the shaping, Claude creates a plan split into tasks, each with a description and a checklist of things to mark it as done.
+- **Building.** Claude executes the plan.
+- **Compounding.** Inspired by the idea of [compound engineering](https://every.to/guides/compound-engineering), Claude captures everything learned during development — good practices, bugs fixed, mistakes to avoid — into a document that feeds future work.
+
+The phase that surprised me most was research. Even when I have no idea where to start, or when I need to touch a feature someone else built that I know little about, the research phase gets me oriented. It's a cure for the "blank page" syndrome, for developers.
+
+I'll be honest: I was skeptical at first. I'm skeptical of every document written with AI, because of AI slop. But I liked this instantly. I felt guided in my development.
+
+And this isn't just me. Most of my teammates are going through the same shift, and the ones who haven't yet are not far behind. We spent energy on making shared skills — the Conductor, review guidelines, workflow improvements. This is a team transition, not a personal experiment.
+
+## One agent, not a fleet
+
+I know many people say they always have a bunch of agents running in parallel. My brain is not wired for that. Every time I tried two or three agents at once, I ended up confusing them, losing track, and switching context too much. One agent is not the most efficient way, but it's the best I've found for how I work. Plus, parallel agents burn through your Claude Code quota terrifyingly fast.
+
+The only exception: sometimes I start a research phase for one feature while I'm building another.
+
+People sometimes frame this as management. It's not. I don't manage an agent — I use it as a tool. If I really wanted to follow the "leading" analogy, I'd say I lead a team of one developer whose work I watch over the shoulder all day. That would be a terrible way to lead a team.
+
+## Unlearning senior
+
+This is the hardest part, and it's not what you'd expect.
+
+As a senior developer, your skills go beyond coding. You learned to challenge requirements from stakeholders. You learned to protect the project from unnecessary complexity. You learned to estimate how long things take. These instincts are what make you senior.
+
+And they're exactly what you need to unlearn.
+
+Everything changes when the cost of trying drops dramatically. When AI coding [crossed the speed threshold](/speed-threshold), making a POC for a new library and migrating all the code stopped being terrifying. Now you can do it in a few hours.
+
+My CTO is ambitious. He'll show up one morning proposing to radically change a full module of the app — a full rewrite, a new API, solving problems we already had with the previous one. The first and second time, I pushed back. I told him it was totally unrealistic, basically a terrible idea.
+
+He was right.
+
+One example: we needed to migrate from one AI framework to another. We all agreed it had to happen, but my boss proposed we do it during a two-week cooldown between feature-building cycles. I told him it was definitely not possible — in two weeks, the best we could do was a POC and then plan a real project, probably four to five weeks. Result: I did the full migration alone in those two weeks. It was the first time I used the Conductor for real.
+
+Another: we were using an existing pipeline to extract metadata from other systems for our clients. It worked, but it wasn't efficient — the pipeline wasn't designed for that. My CTO proposed querying the systems directly through their APIs. I pushed back: we'd be spending time we didn't have reimplementing something that already worked. He convinced me a POC was cheap. It was. In one afternoon, Claude built one showing it was faster, easier to maintain, and better in every way.
+
+Now I try to have the same mindset. Default to trying, not estimating.
+
+## What's still hard
+
+I don't want this to sound like everything is solved. It's not.
+
+The hard parts hit mid-build. Claude executes a plan, you test manually, and nothing works. We try to mitigate this with better shaping and planning, but it still happens. The first reflex is to go read the code — which works for small features. What I do instead, more and more: tell Claude what's broken (basically QA), then ask it to explain what might be causing it. Sometimes I ask it to walk me through how the feature works in the code, so I can point it in the right direction.
+
+No magic recipe. But this is where you realize the debugging skills you built over ten years still matter. You don't read the code as much, but you still read the logs, ask for tests, think about what could go wrong.
+
+Code review is another unsolved problem. Our velocity is too high for every PR to get a human review. I don't always master 100% of the code in my PRs — I haven't written it. I used to read all the LLM-generated code to make it my own. Increasingly, I've stopped. I treat code written by Claude the way I'd treat code from a colleague: I want the high-level picture, not every implementation detail. We're building review skills specific to our codebase, extracting our colleagues' review processes so Claude can catch issues before a PR even goes out.
+
+If we want to maintain the quality of our code, I think we'll still need some human review. But it can't stay at the PR level. Maybe architecture reviews at the end of a project. I don't have answers yet — that's probably another post.
+
+And then there's the future. My job changed dramatically in the past year, but most of that change landed in the last three months. What it looks like a year from now? No idea. Any new model could reshuffle everything. Exciting and FUD at the same time.
+
+## It was true the whole time
+
+So what makes me a developer if I don't write code?
+
+Tough question. For my entire career, I heard — and even said, a lot — that being a developer wasn't mostly about writing code. It was about solving problems, hearing requirements, making compromises, presenting solutions, working as a team.
+
+Turns out it was true the whole time.
+
+---
+
+Some developer friends of mine haven't taken the AI turn yet. At best they use Tab autocomplete in Copilot or Cursor. When I tell them about these changes, they look at me and say something like: "Oh, so you realized you actually didn't like coding."
+
+That couldn't be more wrong.
+
+I've always liked coding. I built many side projects, took pleasure in learning several languages — even some I have never used to build an actual app (hello, Haskell!). I wrote blog posts and even books about programming.
+
+One thing is true: I take little pleasure in writing code now. But it is because I found other ways to build applications, solve problems, and overcome technical challenges. More efficient ways, that let me focus on higher-level concerns.
+
+And more important: it is still a lot of fun. Probably even more.

--- a/_research/not-the-same-job/interview.md
+++ b/_research/not-the-same-job/interview.md
@@ -1,0 +1,71 @@
+# Interview — Not the Same Job
+
+## Round 1
+**Q:**
+1. Was there a specific moment — a task, a day, a conversation — where you first thought "this isn't the same job anymore"? What were you doing?
+2. If you compare a typical workday now to a typical workday a year ago, what's the most obvious difference in how you spend your time?
+3. When you say "not the same job," is that exciting, unsettling, or both?
+
+**A:**
+1. It was more a progressive process: first when I started using Cursor and I mostly used Tab feature, then using agent mode in Codex, Claude Code or Cursor again, and now using exclusively Claude Code with custom skills for planning, shaping, building and compounding.
+2. The main difference is that I don't write code anymore. I still deliver features, solve problems, tackle architecture challenges, even review code (LLM or other PRs), but it's been three months that I haven't written a line of code myself. Yet I still consider myself a developer; I'm not a PM, I'm not a tech lead with a team of agents.
+3. Definitely exciting, because I'm learning new stuff everyday, and feel I can accomplish so much more than before. But at the same time, a bit weird not to know what I'll do in another year.
+
+## Round 2
+**Q:**
+1. If you don't write code, what do you actually do all day? Walk me through what a productive morning looks like now — what are you typing, reading, deciding?
+2. You mention "planning, shaping, building and compounding" as custom skills. That vocabulary sounds deliberate — when did you start thinking about your work in those terms? Did naming those phases change how you approach things?
+3. "I'm not a tech lead with a team of agents" — what makes it different from managing a team? Because from the outside, "reviewing AI-generated code and directing what gets built" sounds a lot like leading.
+
+**A:**
+1 & 2: With my team, we created a skill named 'Conductor' with a set of subskills that reflect our workflow:
+a. Research: I ask Claude Code to make a research on the feature I need to build. Research can extract info from the existing code, from our Notion pages, from Slack, from the web (if using a new library or infra feature for instance). The result is a Markdown document with all the research content, and more importantly a list of open questions.
+b. Shaping: once the research is done, the next step is to shape the feature to make sure the problem we want to solve is clear, as well as the solution we chose to implement. At the end of the shaping, there should ideally be no more unknowns. The shaping document (still Markdown) should be understandable by any nontechnical person (i.e. stakeholders).
+c. Planning: this is where from the shaping, we ask Claude to create a plan, split into tasks. Each task should contain a description of what needs to be done (usually the research phase identified already the places in the code to update, which services or modules), and a checklist of things to mark the task as done.
+d. Building: this is when Claude executes the plan.
+e. Compounding: after building (and usually after manual testing and using other skills for code review), Claude creates or updates a compound document that contains everything that was learned during the feature development. It can be good practices discovered, existing bugs fixed, mistakes made and how to avoid them, etc. The compound document is supposed to be used on later features. (At the end of a project, we usually consolidate all compound documents into a more condensed one to avoid obvious scalability issues.)
+
+3: First, I usually work with only one agent. I know many people say they always have a bunch of agents running, but my brain is not wired for that. Each time I tried to work with two or three parallel agents, I ended up making mistakes, confusing agents, losing track, and switching context too much. One agent might not be the most efficient way, but it is still the best I found for my usage (plus, when I tried running several agents at the same time, my Claude Code quota exploded way too quickly). The only exception: sometimes I start a research phase for a feature while working on another one.
+Secondly, I don't feel I'm _managing_ an agent. I execute it as a tool. If I really wanted to follow the 'leading' analogy, I could say that I lead a team of one developer, whose work I watch over the shoulder all day. That would be a terrible way to lead a team.
+
+## Round 3
+**Q:**
+1. You described a five-phase workflow that looks very structured. A year ago, when you were writing code by hand, did you have anything like that structure — or is that something you built specifically because you needed it once the agent was doing the coding?
+2. You mentioned reviewing code — LLM-generated or other PRs. Has what you look for in a code review changed? Do you read AI-generated code differently than you'd read a colleague's PR?
+3. What's the hardest part of this new way of working — the thing that's still uncomfortable or that you haven't figured out yet?
+
+**A:**
+1. It is something we built about three months ago. We wanted to start using Claude Code not only for writing code, but also to help us plan better our development workflow. I was a bit skeptical at first (as I was with every document written with AI, because of AI slop), but it turns out I liked it instantly. I felt guided in my development. Even when sometimes I have something to build and I have no idea where to start, or even when I need to update a feature built by someone else that I know little about, the research phase will help me understand what it is about. It's like a solution to the 'blank page' syndrome, for developers.
+
+2. I feel we have not nailed code review in an agentic world yet. We're all aware that it is not realistic anymore to expect each PR to be reviewed by another developer. Our velocity is too high, plus I don't always master 100% of the code of my PRs (because I haven't written it). A while ago, I would have read all the LLM generated code of my PRs, to make it my own. More and more I stopped doing that, and consider the code written by Claude the same as I would consider the code by another colleague: I want to understand the high-level overview, but not the technical implementation details. Although we haven't done it enough yet I think, we start improving our code review skills, to make them relevant specifically with our code base, and our practices. Some of my colleagues still take time to review my code for parts I am out of my comfort zone (backend services, infra), but then we try to extract their review process into skills to make Claude able to fix what it can even before sending the PR for review. More and more I think that PRs are not the best media for code reviews anymore. I don't have ideas about it, and it is another topic, but worth thinking about maybe for another post.
+
+3. Unlearning what you know. As a senior developer, your skills are not only about coding: you learned how to challenge the requirements you get from stakeholders, you learned to protect the project you're working on from too complex requirements, and you learned how to estimate the necessary time to build something. Everything changes with AI: making a POC for using a new library and migrating all the code could be very scary a few months ago; but maybe now you can do it in a few hours with AI. My boss and CTO is a very ambitious person, who can come to you one morning telling you he'd like us to radically change a full module of the app that would require a full rewriting, learning how to use a new API, solving problems we had already with the previous one, etc. The first and second time, I may have reacted by pushing back, telling him that it was totally unrealistic in the given amount of time, and that it was basically a terrible idea. But as most of the time, he was right, convinced me to at least try with Claude, and it was always a success. Now I try to have the same mindset.
+
+## Round 4
+**Q:**
+1. You said you "still consider yourself a developer." What makes you a developer if it's not writing code? What's the core of the identity that survived the transition?
+2. The CTO story is great — you pushed back, he was right, and now you've recalibrated. Can you give a concrete example of one of those moments? What was the request, what was your gut reaction, and what actually happened when you tried it with Claude?
+3. You mentioned the "blank page syndrome" being solved by the research phase. Has this changed which kinds of work feel hard? Like, if the blank page isn't the scary part anymore, what is?
+
+**A:**
+1. This is a tough one. For all my career I heard (and even said a lot) that being a developer was not mostly about writing code. It was about solving problems, technical or product-related, hearing requirements, making compromises, presenting solutions, working as teams, etc. Today I realize it more and more that it was true the whole time.
+
+2. Two examples:
+- First: migrating from one AI framework to another. We were not satisfied with the one we had, and we identified a great challenger; we all agreed we had to migrate. But my boss proposed we did it during a two-week period (that we call cooldowns) between feature-building cycles. At first I told him it was definitely not possible, that in two weeks the best we could do was to make a POC, and plan an actual project that would probably take four to five weeks building. Result: I did the full migration by myself during the two weeks, and everything went as smoothly as it could have. Turns out it was the first time I used the conductor skills for real, to plan the whole migration and assist me during.
+- Second: to extract some information from other systems for our clients, we used to rely on a pipeline we already had built for our product. It worked okay, but was not really efficient because this is not what the pipeline had been designed for (we needed to extract metadata, which is a tiny part of what the pipeline had to deal with). So my CTO proposed us to query the systems directly, using their respective APIs. Again I pushed back, because it meant spending time we didn't have reimplementing something we had already. He convinced me that doing a POC was cheap, and it was: in one afternoon Claude had built a POC showing us it was more efficient, easier to maintain, and offered many advantages.
+
+3. The hard parts arrive in the middle of building a feature. When Claude Code executed a plan, and you test manually, and nothing works as expected. This is a scenario we try to mitigate by caring a lot about shaping and planning features, but it still happens. In these scenarios, the first reflex can be to go have a look at the code; which can work for small features. What I try to do more and more: first tell Claude what doesn't work (basically doing QA), then ask it to explain me what the source of the issue can be. Sometimes, I even ask it to explain me how the feature works in the code; it can help me direct it to find the issue source. There is no magic recipe here, but this is where you understand that the debugging skills you learned for the past 10 years are still relevant. Maybe you don't read the code as much, but you still have to read the logs, ask for tests, etc.
+
+## Round 5 (unprompted — closing thought from Sebastien)
+
+I have some developer friends who haven't taken the AI-turn (yet). At best they use a bit the Tab autocomplete feature of Copilot or Cursor. When I tell them about these changes, they look at me weirdly and tell me something like "oh, you realized you actually didn't like coding". That couldn't be more wrong! I've always liked coding: I built many side projects, took pleasure in learning several languages even some I have never used to build an actual app (hello, Haskell!), wrote blog posts and even books about programming, etc. One thing is true: I take little pleasure in writing code now; but it is because I found other ways to build applications, solve problems and overcome technical challenges! More efficient ways, that let you focus on higher-level concerns. And more important: it is still a lot of fun, and probably even more!
+
+## Round 6 (filling gaps)
+**Q:** Three things from the outline flagged as missing: (1) the "what will I do in another year" uncertainty, (2) code review beyond PRs, (3) whether teammates are going through the same shift.
+
+**A:**
+1. My job has changed so much in the last year, but most of the changes happened in the last three months, so it is hard to know what it will become in another year. It will also depend on the technical improvements that'll happen in the industry. Any new Claude model could reshuffle everything. Exciting and FUD (fear-uncertainty-doubt) at the same time.
+
+2. Yeah, if we want to maintain the quality of our application code, I think we'll still need some human review, but it can't stay at the PR level. Maybe architecture review at the end of a project...
+
+3. Most of them are going through the same shift, and the ones that do not are not far behind. We spent energy on making shared skills (the conductor ones), improving our workflows with agents, establishing guidelines for Claude Code to use during code review, etc.

--- a/_research/not-the-same-job/outline.md
+++ b/_research/not-the-same-job/outline.md
@@ -1,0 +1,82 @@
+# Still a Developer (I Think)
+
+## Angle
+The job title says "developer" but the job itself has quietly become something else — not management, not product, but a new kind of technical work where the hardest part isn't learning new tools, it's unlearning the instincts that made you senior.
+
+## Hook
+Three months without writing a single line of code. Still shipping features, still solving architecture problems, still reviewing PRs. Still a developer — but not doing the same job as a year ago.
+
+## Sections
+
+### 1. The Gradient, Not the Cliff
+**Purpose:** Show this wasn't a sudden switch but a progressive shift, so readers who are somewhere on the spectrum can place themselves.
+**Key points:**
+- Started with Cursor Tab completions, moved to agent mode (Codex, Claude Code, Cursor), now exclusively Claude Code with custom skills
+- The progression was gradual enough that the full weight of the change only hit in retrospect
+**Quotes/phrases to use:** "it was more a progressive process"
+
+### 2. What I Actually Do All Day
+**Purpose:** Replace the abstract "I don't write code" with a concrete picture of the new workflow — the Conductor system.
+**Key points:**
+- The five phases: Research, Shaping, Planning, Building, Compounding
+- Research pulls from code, Notion, Slack, the web — produces a doc with open questions; solves the "blank page syndrome" for developers
+- Shaping produces a document any non-technical person could understand — no more unknowns
+- Planning splits work into tasks with checklists
+- Building is Claude executing the plan
+- Compounding captures what was learned — good practices, bugs found, mistakes to avoid — and feeds future work
+- This workflow was built specifically for the AI era, not inherited from before; was skeptical at first (AI slop concern) but liked it instantly — "I felt guided in my development"
+- Not a solo journey: team invested in shared skills (the Conductor), shared workflows, shared review guidelines — most teammates going through the same shift, the rest not far behind
+**Quotes/phrases to use:** "it's like a solution to the 'blank page' syndrome, for developers"; "I felt guided in my development"
+
+### 3. One Agent, Not a Fleet
+**Purpose:** Push back against the "swarm of agents" narrative and explain why this isn't management.
+**Key points:**
+- Works with one agent at a time — parallel agents led to mistakes, confusion, context-switching, and blown quotas
+- Exception: sometimes starts a research phase for one feature while building another
+- Doesn't feel like managing — "I execute it as a tool"
+- The management analogy breaks down: "I lead a team of one developer, whose work I watch over the shoulder all day. That would be a terrible way to lead a team."
+**Quotes/phrases to use:** "my brain is not wired for that"; "I execute it as a tool"; the "watching over the shoulder" line
+
+### 4. Unlearning Senior
+**Purpose:** The core tension — AI doesn't just add new skills, it invalidates instincts you spent years building. This is the hardest part.
+**Key points:**
+- Senior developer instincts: challenge requirements, protect the project from complexity, estimate conservatively
+- These instincts become wrong when the cost of trying drops dramatically
+- The CTO stories: framework migration estimated at 4-5 weeks, done in 2 weeks; API extraction POC built in one afternoon
+- "The first and second time, I may have reacted by pushing back… But he was right"
+- Now tries to adopt that same mindset — default to trying instead of estimating
+**Quotes/phrases to use:** "it was definitely not possible"; "doing a POC was cheap, and it was"; "he was right, convinced me to at least try with Claude, and it was always a success"
+
+### 5. What's Still Hard
+**Purpose:** Honesty about the rough edges — this isn't a utopia post.
+**Key points:**
+- The hard part is mid-build: when Claude executes the plan and manual testing reveals nothing works as expected
+- Mitigation: invest heavily in shaping and planning, but it still happens
+- Debugging approach has changed: first do QA (tell Claude what's broken), then ask Claude to explain what the issue could be, sometimes ask it to explain how the feature works in the code
+- Debugging skills from 10 years are still relevant — you still read logs, ask for tests
+- Code review is unsolved: velocity too high for human review of every PR, stopped reading all LLM code line-by-line, starting to treat AI code like a colleague's code (understand high-level, not every detail), building review skills into Claude. Human review still needed for quality, but probably at the architecture level at end of project, not per-PR. (Flag as future post topic.)
+- The future is genuinely unknown: most changes happened in the last three months, any new model could reshuffle everything. Exciting and FUD at the same time.
+**Quotes/phrases to use:** "this is where you understand that the debugging skills you learned for the past 10 years are still relevant"; "I consider the code written by Claude the same as I would consider the code by another colleague"; "exciting and FUD at the same time"
+
+### 6. It Was True the Whole Time
+**Purpose:** The identity answer — what makes you a developer if not code.
+**Key points:**
+- "For all my career I heard that being a developer was not mostly about writing code" — solving problems, hearing requirements, making compromises, presenting solutions, working as teams
+- "Today I realize it more and more that it was true the whole time"
+- Brief bridge to the closing
+**Quotes/phrases to use:** "it was true the whole time"
+
+## Closing
+**Purpose:** Address the skeptics directly and end on the emotional truth — this is more fun, not less.
+**Key points:**
+- Friends who haven't taken the AI turn say "oh, you realized you actually didn't like coding"
+- Rebuttal: side projects, multiple languages (hello, Haskell!), blog posts, books about programming
+- The honest admission: "I take little pleasure in writing code now"
+- The reframe: found other ways to build, solve, and overcome — more efficient, higher-level, and still a lot of fun
+**Quotes/phrases to use:** "that couldn't be more wrong!"; "hello, Haskell!"; "it is still a lot of fun, and probably even more!"
+
+## What's Missing
+All three gaps are now filled:
+- ~~Uncertainty about the future~~ → Added to Section 5 ("What's Still Hard"): most changes happened in the last three months, any new model could reshuffle everything, exciting and FUD at the same time
+- ~~Code review beyond PRs~~ → Brief mention in Section 5: human review still needed for quality, but maybe at the architecture level at end of project, not PR level
+- ~~Team experience~~ → Woven into Section 2: this isn't a solo journey — shared skills, shared workflows, shared guidelines

--- a/content/if-claude-writes-the-code.en.md
+++ b/content/if-claude-writes-the-code.en.md
@@ -1,6 +1,6 @@
 ---
 title: "If Claude Writes the Code, What Makes Me Still a Developer?"
-slug: "not-the-same-job"
+slug: "if-claude-writes-the-code"
 date: 2026-04-30
 ---
 
@@ -70,7 +70,7 @@ No magic recipe. But this is where you realize the debugging skills you built ov
 
 Code review is another unsolved problem. Our velocity is too high for every PR to get a human review. I don't always master 100% of the code in my PRs — I haven't written it. I used to read all the LLM-generated code to make it my own. Increasingly, I've stopped. I treat code written by Claude the way I'd treat code from a colleague: I want the high-level picture, not every implementation detail. We're building review skills specific to our codebase, extracting our colleagues' review processes so Claude can catch issues before a PR even goes out.
 
-If we want to maintain the quality of our code, I think we'll still need some human review. But it can't stay at the PR level. Maybe architecture reviews at the end of a project. I don't have answers yet — that's probably another post.
+Today, the risk is manageable. All our features ship behind feature flags, so the blast radius of a mistake is limited. And we still know the codebase extremely well — we're good at spotting risky code, and we know which practices to enforce to maintain quality. But long-term, I see the tension: the more AI-written code accumulates, the more control we could lose over overall codebase quality. That's why we keep investing in better skills and guidelines — it's not a problem you solve once, it's one you have to keep up with. Probably another post in itself.
 
 And then there's the future. My job changed dramatically in the past year, but most of that change landed in the last three months. What it looks like a year from now? No idea. Any new model could reshuffle everything. Exciting and FUD at the same time.
 
@@ -80,7 +80,7 @@ So what makes me a developer if I don't write code?
 
 Tough question. For my entire career, I heard — and even said, a lot — that being a developer wasn't mostly about writing code. It was about solving problems, hearing requirements, making compromises, presenting solutions, working as a team.
 
-Turns out it was true the whole time.
+Turns out it was true the whole time. At least, that's what I believe today. I'm also aware I'm saying this mid-transition — three months into a shift that's still accelerating. I might read this post in a year and think I was naive about what was coming next.
 
 ---
 

--- a/content/if-claude-writes-the-code.fr.md
+++ b/content/if-claude-writes-the-code.fr.md
@@ -1,0 +1,95 @@
+---
+title: "Si Claude écrit le code, qu'est-ce qui fait de moi un développeur ?"
+slug: "si-claude-ecrit-le-code"
+date: 2026-04-30
+---
+
+Ça fait trois mois que je n'ai pas écrit une seule ligne de code.
+
+Je livre toujours des features. Je résous toujours des problèmes, je m'attaque à des défis d'architecture, je review des PRs. Je ne suis pas PM. Je ne suis pas tech lead avec une équipe d'agents. Je me considère toujours comme développeur. Mais je ne fais plus le même métier qu'il y a un an.
+
+## Le dégradé, pas la falaise
+
+Il n'y a pas eu un moment précis où je me suis dit « ce n'est plus le même métier ». C'était un processus progressif. D'abord Cursor, surtout l'autocomplétion Tab — et même ça, ça a [changé ma vision du développement avec l'IA](/deux-heures). Puis le mode agent — Codex, Claude Code, Cursor encore. J'ai [déjà écrit](/three-act-play) sur ces différentes approches. Aujourd'hui je travaille exclusivement avec Claude Code, avec des skills custom que mon équipe et moi avons construits pour la planification, le shaping, le building et le compounding.
+
+Le changement a été assez progressif pour que je n'en mesure le poids qu'avec le recul. Si tu es quelque part sur ce spectre — tu utilises Copilot pour l'autocomplétion, ou tu as essayé le mode agent une ou deux fois — tu es sur le même dégradé. Tu n'as juste pas encore regardé en arrière.
+
+## Ce que je fais de mes journées
+
+Donc si je n'écris pas de code, je fais quoi ?
+
+Avec mon équipe, on a construit un ensemble de skills Claude Code qu'on appelle le Conductor. C'est né de [mes premières expériences avec le développement guidé par un plan](/partenaire-design), et ça couvre tout notre workflow en cinq phases :
+
+- **Research.** Je demande à Claude de faire des recherches sur la feature à construire. Il fouille dans le codebase existant, nos pages Notion, les conversations Slack, le web — tout ce qui est pertinent. Le résultat est un document Markdown avec tout le contenu de recherche, et surtout, une liste de questions ouvertes.
+- **Shaping.** On cadre la feature pour s'assurer que le problème et la solution choisie sont clairs. À la fin du shaping, il ne devrait idéalement plus y avoir d'inconnues — le document doit être compréhensible par n'importe quelle personne non technique.
+- **Planning.** À partir du shaping, Claude crée un plan découpé en tâches, chacune avec une description et une checklist pour la marquer comme terminée.
+- **Building.** Claude exécute le plan.
+- **Compounding.** Inspiré par l'idée de [compound engineering](https://every.to/guides/compound-engineering), Claude capture tout ce qui a été appris pendant le développement — bonnes pratiques, bugs corrigés, erreurs à éviter — dans un document qui nourrit le travail futur.
+
+La phase qui m'a le plus surpris, c'est la recherche. Même quand je n'ai aucune idée par où commencer, ou quand je dois toucher à une feature construite par quelqu'un d'autre que je connais mal, la phase de recherche m'oriente. C'est un remède au syndrome de la « page blanche », pour les développeurs.
+
+Je vais être honnête : j'étais sceptique au départ. Je suis sceptique face à tout document écrit par une IA, à cause du slop. Mais là, j'ai aimé ça tout de suite. Je me sentais guidé dans mon développement.
+
+Et ce n'est pas que moi. La plupart de mes collègues vivent le même changement, et ceux qui ne l'ont pas encore fait ne sont pas loin derrière. On a investi du temps dans des skills partagés — le Conductor, des guidelines de review, des améliorations de workflow. C'est une transition d'équipe, pas une expérience personnelle.
+
+## Un agent, pas une flotte
+
+Je sais que beaucoup de gens disent qu'ils ont toujours plein d'agents qui tournent en parallèle. Mon cerveau n'est pas câblé pour ça. À chaque fois que j'ai essayé avec deux ou trois agents en même temps, j'ai fini par les confondre, perdre le fil, et faire trop de context switching. Un seul agent, ce n'est pas le plus efficace, mais c'est ce qui marche le mieux pour moi. En plus, les agents en parallèle, ça explose ton quota Claude Code à une vitesse terrifiante.
+
+La seule exception : parfois je lance une phase de recherche pour une feature pendant que j'en construis une autre.
+
+Certains présentent ça comme du management. Ce n'en est pas. Je ne manage pas un agent — je l'utilise comme un outil. Si je voulais vraiment filer l'analogie du « leadership », je dirais que je manage une équipe d'un seul développeur dont je surveille le travail par-dessus l'épaule toute la journée. Ce serait une façon terrible de manager une équipe.
+
+## Désapprendre la séniorité
+
+C'est la partie la plus difficile, et ce n'est pas celle qu'on imagine.
+
+En tant que développeur senior, tes compétences vont au-delà du code. Tu as appris à challenger les exigences des stakeholders. Tu as appris à protéger le projet de la complexité inutile. Tu as appris à estimer combien de temps les choses prennent. Ces instincts sont ce qui fait de toi un senior.
+
+Et ce sont exactement ceux qu'il faut désapprendre.
+
+Tout change quand le coût d'essayer chute drastiquement. Quand le coding IA a [franchi le seuil de vitesse](/seuil-vitesse), faire un POC pour une nouvelle librairie et migrer tout le code a cessé d'être effrayant. Maintenant tu peux le faire en quelques heures.
+
+Mon CTO est ambitieux. Il débarque un matin en proposant de changer radicalement un module entier de l'app — une réécriture complète, une nouvelle API, résoudre des problèmes qu'on avait déjà avec la précédente. Les première et deuxième fois, j'ai résisté. Je lui ai dit que c'était totalement irréaliste, que c'était une très mauvaise idée.
+
+Il avait raison.
+
+Un exemple : on devait migrer d'un framework d'IA à un autre. On était tous d'accord pour le faire, mais mon boss a proposé qu'on le fasse pendant un cooldown de deux semaines entre deux cycles de features. Je lui ai dit que c'était clairement impossible — en deux semaines, le mieux qu'on pouvait faire c'était un POC, puis planifier un vrai projet, probablement quatre à cinq semaines. Résultat : j'ai fait toute la migration seul en deux semaines. C'était la première fois que j'utilisais le Conductor pour de vrai.
+
+Autre exemple : on utilisait un pipeline existant pour extraire des métadonnées d'autres systèmes pour nos clients. Ça marchait, mais ce n'était pas efficace — le pipeline n'avait pas été conçu pour ça. Mon CTO a proposé de requêter les systèmes directement via leurs APIs. J'ai résisté : on allait passer du temps qu'on n'avait pas à reimplémenter quelque chose qui marchait déjà. Il m'a convaincu qu'un POC ne coûtait pas cher. C'était vrai. En un après-midi, Claude en a construit un qui montrait que c'était plus rapide, plus facile à maintenir, et meilleur en tout point.
+
+Maintenant j'essaie d'adopter le même état d'esprit. Par défaut, essayer plutôt qu'estimer.
+
+## Ce qui est encore difficile
+
+Je ne veux pas que ça sonne comme si tout était résolu. Ce n'est pas le cas.
+
+Les moments difficiles arrivent en plein milieu du build. Claude exécute un plan, tu testes manuellement, et rien ne marche. On essaie d'atténuer ça avec un meilleur shaping et planning, mais ça arrive quand même. Le premier réflexe, c'est d'aller lire le code — ce qui marche pour les petites features. Ce que je fais de plus en plus à la place : dire à Claude ce qui ne marche pas (faire de la QA, en gros), puis lui demander d'expliquer ce qui pourrait causer le problème. Parfois je lui demande de m'expliquer comment la feature fonctionne dans le code, pour pouvoir le pointer dans la bonne direction.
+
+Pas de recette magique. Mais c'est là qu'on réalise que les compétences de debugging construites pendant dix ans comptent encore. Tu lis moins le code, mais tu lis toujours les logs, tu demandes des tests, tu réfléchis à ce qui pourrait mal tourner.
+
+La code review est un autre problème non résolu. Notre vélocité est trop élevée pour que chaque PR soit review par un humain. Je ne maîtrise pas toujours 100% du code de mes PRs — je ne l'ai pas écrit. Avant, j'aurais lu tout le code généré par le LLM pour me l'approprier. De plus en plus, j'ai arrêté. Je traite le code écrit par Claude comme celui d'un collègue : je veux la vision d'ensemble, pas chaque détail d'implémentation. On construit des skills de review spécifiques à notre codebase, on extrait les processus de review de nos collègues pour que Claude puisse corriger les problèmes avant même qu'une PR soit envoyée.
+
+Aujourd'hui, le risque est gérable. Toutes nos features sont derrière des feature flags, donc le rayon d'impact d'une erreur est limité. Et on connaît toujours extrêmement bien le codebase — on sait repérer le code risqué, et on sait quelles pratiques maintenir pour garantir la qualité. Mais à long terme, je vois la tension : plus le code écrit par l'IA s'accumule, plus on risque de perdre le contrôle sur la qualité globale du codebase. C'est pour ça qu'on investit en permanence dans de meilleurs skills et guidelines — ce n'est pas un problème qu'on résout une fois, c'est un problème qu'il faut suivre en continu. Sûrement un autre post en soi.
+
+Et puis il y a le futur. Mon métier a changé radicalement en un an, mais l'essentiel de ce changement s'est concentré sur les trois derniers mois. À quoi ça ressemble dans un an ? Aucune idée. Chaque nouveau modèle pourrait tout rebattre. Excitant et FUD en même temps.
+
+## C'était vrai depuis le début
+
+Alors qu'est-ce qui fait de moi un développeur si je n'écris pas de code ?
+
+Question difficile. Pendant toute ma carrière, j'ai entendu — et même beaucoup dit — qu'être développeur, ce n'était pas principalement écrire du code. C'était résoudre des problèmes, comprendre les besoins, faire des compromis, présenter des solutions, travailler en équipe.
+
+Il s'avère que c'était vrai depuis le début. Du moins, c'est ce que je crois aujourd'hui. Je suis aussi conscient que je dis ça en pleine transition — trois mois dans un changement qui continue de s'accélérer. Je relirai peut-être ce post dans un an en me disant que j'étais naïf sur ce qui allait suivre.
+
+---
+
+Certains de mes amis développeurs n'ont pas encore pris le virage de l'IA. Au mieux, ils utilisent l'autocomplétion Tab de Copilot ou Cursor. Quand je leur parle de ces changements, ils me regardent et me disent un truc du genre : « Ah, donc en fait tu t'es rendu compte que t'aimais pas coder. »
+
+Rien ne pourrait être plus faux.
+
+J'ai toujours aimé coder. J'ai construit plein de side projects, pris plaisir à apprendre plusieurs langages — même certains que je n'ai jamais utilisés pour construire une vraie app (coucou, Haskell !). J'ai écrit des articles de blog et même des livres sur la programmation.
+
+Une chose est vraie : je prends peu de plaisir à écrire du code aujourd'hui. Mais c'est parce que j'ai trouvé d'autres façons de construire des applications, résoudre des problèmes et surmonter des défis techniques. Des façons plus efficaces, qui me permettent de me concentrer sur des préoccupations de plus haut niveau.
+
+Et surtout : c'est toujours aussi fun. Probablement même plus.

--- a/content/not-the-same-job.en.md
+++ b/content/not-the-same-job.en.md
@@ -1,0 +1,95 @@
+---
+title: "If Claude Writes the Code, What Makes Me Still a Developer?"
+slug: "not-the-same-job"
+date: 2026-04-30
+---
+
+It's been three months since I last wrote a line of code.
+
+I still deliver features. I still solve problems, tackle architecture challenges, review PRs. I'm not a PM. I'm not a tech lead with a team of agents. I still consider myself a developer. But I am not doing the same job I was doing a year ago.
+
+## The gradient, not the cliff
+
+There was no single moment where I thought "this isn't the same job anymore." It was a progressive process. First Cursor, mostly the Tab autocomplete — and even that [changed my mind about AI coding](/two-hours). Then agent mode — Codex, Claude Code, Cursor again. I've [written before](/three-act-play) about these different approaches. Now I work exclusively with Claude Code, with custom skills my team and I built for planning, shaping, building, and compounding.
+
+The shift was gradual enough that I only felt the full weight of it in retrospect. If you're somewhere on that spectrum — using Copilot for autocomplete, or you've tried agent mode once or twice — you're on the same gradient. You just haven't looked back yet.
+
+## What I actually do all day
+
+So if I don't write code, what do I do?
+
+With my team, we built a set of Claude Code skills we call the Conductor. It grew out of [my early experiments with plan-driven development](/design-partner), and it covers our entire workflow in five phases:
+
+- **Research.** I ask Claude to research the feature I need to build. It pulls from the existing codebase, our Notion pages, Slack conversations, the web — whatever's relevant. The output is a Markdown document with all the research content, and more importantly, a list of open questions.
+- **Shaping.** We shape the feature to make sure the problem and the chosen solution are clear. At the end of the shaping, there should ideally be no more unknowns — the document should be understandable by any non-technical person.
+- **Planning.** From the shaping, Claude creates a plan split into tasks, each with a description and a checklist of things to mark it as done.
+- **Building.** Claude executes the plan.
+- **Compounding.** Inspired by the idea of [compound engineering](https://every.to/guides/compound-engineering), Claude captures everything learned during development — good practices, bugs fixed, mistakes to avoid — into a document that feeds future work.
+
+The phase that surprised me most was research. Even when I have no idea where to start, or when I need to touch a feature someone else built that I know little about, the research phase gets me oriented. It's a cure for the "blank page" syndrome, for developers.
+
+I'll be honest: I was skeptical at first. I'm skeptical of every document written with AI, because of AI slop. But I liked this instantly. I felt guided in my development.
+
+And this isn't just me. Most of my teammates are going through the same shift, and the ones who haven't yet are not far behind. We spent energy on making shared skills — the Conductor, review guidelines, workflow improvements. This is a team transition, not a personal experiment.
+
+## One agent, not a fleet
+
+I know many people say they always have a bunch of agents running in parallel. My brain is not wired for that. Every time I tried two or three agents at once, I ended up confusing them, losing track, and switching context too much. One agent is not the most efficient way, but it's the best I've found for how I work. Plus, parallel agents burn through your Claude Code quota terrifyingly fast.
+
+The only exception: sometimes I start a research phase for one feature while I'm building another.
+
+People sometimes frame this as management. It's not. I don't manage an agent — I use it as a tool. If I really wanted to follow the "leading" analogy, I'd say I lead a team of one developer whose work I watch over the shoulder all day. That would be a terrible way to lead a team.
+
+## Unlearning senior
+
+This is the hardest part, and it's not what you'd expect.
+
+As a senior developer, your skills go beyond coding. You learned to challenge requirements from stakeholders. You learned to protect the project from unnecessary complexity. You learned to estimate how long things take. These instincts are what make you senior.
+
+And they're exactly what you need to unlearn.
+
+Everything changes when the cost of trying drops dramatically. When AI coding [crossed the speed threshold](/speed-threshold), making a POC for a new library and migrating all the code stopped being terrifying. Now you can do it in a few hours.
+
+My CTO is ambitious. He'll show up one morning proposing to radically change a full module of the app — a full rewrite, a new API, solving problems we already had with the previous one. The first and second time, I pushed back. I told him it was totally unrealistic, basically a terrible idea.
+
+He was right.
+
+One example: we needed to migrate from one AI framework to another. We all agreed it had to happen, but my boss proposed we do it during a two-week cooldown between feature-building cycles. I told him it was definitely not possible — in two weeks, the best we could do was a POC and then plan a real project, probably four to five weeks. Result: I did the full migration alone in those two weeks. It was the first time I used the Conductor for real.
+
+Another: we were using an existing pipeline to extract metadata from other systems for our clients. It worked, but it wasn't efficient — the pipeline wasn't designed for that. My CTO proposed querying the systems directly through their APIs. I pushed back: we'd be spending time we didn't have reimplementing something that already worked. He convinced me a POC was cheap. It was. In one afternoon, Claude built one showing it was faster, easier to maintain, and better in every way.
+
+Now I try to have the same mindset. Default to trying, not estimating.
+
+## What's still hard
+
+I don't want this to sound like everything is solved. It's not.
+
+The hard parts hit mid-build. Claude executes a plan, you test manually, and nothing works. We try to mitigate this with better shaping and planning, but it still happens. The first reflex is to go read the code — which works for small features. What I do instead, more and more: tell Claude what's broken (basically QA), then ask it to explain what might be causing it. Sometimes I ask it to walk me through how the feature works in the code, so I can point it in the right direction.
+
+No magic recipe. But this is where you realize the debugging skills you built over ten years still matter. You don't read the code as much, but you still read the logs, ask for tests, think about what could go wrong.
+
+Code review is another unsolved problem. Our velocity is too high for every PR to get a human review. I don't always master 100% of the code in my PRs — I haven't written it. I used to read all the LLM-generated code to make it my own. Increasingly, I've stopped. I treat code written by Claude the way I'd treat code from a colleague: I want the high-level picture, not every implementation detail. We're building review skills specific to our codebase, extracting our colleagues' review processes so Claude can catch issues before a PR even goes out.
+
+If we want to maintain the quality of our code, I think we'll still need some human review. But it can't stay at the PR level. Maybe architecture reviews at the end of a project. I don't have answers yet — that's probably another post.
+
+And then there's the future. My job changed dramatically in the past year, but most of that change landed in the last three months. What it looks like a year from now? No idea. Any new model could reshuffle everything. Exciting and FUD at the same time.
+
+## It was true the whole time
+
+So what makes me a developer if I don't write code?
+
+Tough question. For my entire career, I heard — and even said, a lot — that being a developer wasn't mostly about writing code. It was about solving problems, hearing requirements, making compromises, presenting solutions, working as a team.
+
+Turns out it was true the whole time.
+
+---
+
+Some developer friends of mine haven't taken the AI turn yet. At best they use Tab autocomplete in Copilot or Cursor. When I tell them about these changes, they look at me and say something like: "Oh, so you realized you actually didn't like coding."
+
+That couldn't be more wrong.
+
+I've always liked coding. I built many side projects, took pleasure in learning several languages — even some I have never used to build an actual app (hello, Haskell!). I wrote blog posts and even books about programming.
+
+One thing is true: I take little pleasure in writing code now. But it is because I found other ways to build applications, solve problems, and overcome technical challenges. More efficient ways, that let me focus on higher-level concerns.
+
+And more important: it is still a lot of fun. Probably even more.


### PR DESCRIPTION
## Summary
- New blog post: "If Claude Writes the Code, What Makes Me Still a Developer?"
- Explores how the developer role has changed after three months of writing zero code, working exclusively with Claude Code and custom skills (the Conductor workflow)
- Includes French translation
- References four existing posts (two-hours, three-act-play, design-partner, speed-threshold)
- Research material (interview, outline, draft) in `_research/not-the-same-job/`

## Test plan
- [ ] Preview locally with `npm run dev` and check rendering at `/if-claude-writes-the-code`
- [ ] Verify internal links to other posts work (EN and FR)
- [ ] Final copy review before publishing

🤖 Generated with [Claude Code](https://claude.com/claude-code)